### PR TITLE
Updated to use the webcam stream.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,28 +6,3 @@ require (
 	github.com/gorilla/websocket v1.4.2
 	github.com/pion/webrtc/v3 v3.0.32
 )
-
-require (
-	github.com/google/uuid v1.2.0 // indirect
-	github.com/pion/datachannel v1.4.21 // indirect
-	github.com/pion/dtls/v2 v2.0.9 // indirect
-	github.com/pion/ice/v2 v2.1.10 // indirect
-	github.com/pion/interceptor v0.0.13 // indirect
-	github.com/pion/logging v0.2.2 // indirect
-	github.com/pion/mdns v0.0.5 // indirect
-	github.com/pion/randutil v0.1.0 // indirect
-	github.com/pion/rtcp v1.2.6 // indirect
-	github.com/pion/rtp v1.6.5 // indirect
-	github.com/pion/sctp v1.7.12 // indirect
-	github.com/pion/sdp/v3 v3.0.4 // indirect
-	github.com/pion/srtp/v2 v2.0.2 // indirect
-	github.com/pion/stun v0.3.5 // indirect
-	github.com/pion/transport v0.12.3 // indirect
-	github.com/pion/turn/v2 v2.0.5 // indirect
-	github.com/pion/udp v0.1.1 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
-	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 // indirect
-	golang.org/x/net v0.0.0-20210614182718-04defd469f4e // indirect
-	golang.org/x/sys v0.0.0-20210423082822-04245dca01da // indirect
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-)

--- a/main.go
+++ b/main.go
@@ -1,18 +1,20 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
-	"log"
-	"net/http"
 	"os"
 	"time"
+	"log"
+	"net/http"
+	"io"
 
+	"encoding/json"
 	"github.com/gorilla/websocket"
+
+//	"github.com/pion/interceptor"
+	"github.com/pion/rtcp"
 	"github.com/pion/webrtc/v3"
-	"github.com/pion/webrtc/v3/pkg/media"
-	"github.com/pion/webrtc/v3/pkg/media/ivfreader"
+//	"github.com/pion/webrtc/v3/examples/internal/signal"
 )
 
 const homeHTML = `<!DOCTYPE html>
@@ -20,51 +22,146 @@ const homeHTML = `<!DOCTYPE html>
 	<head>
 		<title>synced-playback</title>
 	</head>
-	<body id="body">
-		<video id="video" autoplay playsinline></video>
+	<style>
+		table {
+			width: 100%;
+			background: #ccc;
+		}
+		td {
+			width: 50%;
+			padding: 0.25em;
+			text-align: center;
+		}
+		video {
+			background: #000;
+			width: 100%;
+		}
+		.controls {
+			background: #ccc;
+			padding: 0.5em;
+			margin-top: 1em;
+		}
+	</style>
+	<body>
+		<table>
+			<tbody>
+				<tr><td>Local</td><td>Loopback</td></td>
+				<tr>
+					<td><video id="localVideo" autoplay playsinline mute></video></td>
+					<td><video id="remoteVideo" autoplay playsinline mute></video></td>
+				</tr>
+			</tbody>
+		<table>
+		<div class="controls">
+			<button id="start">Start</button>
+			<button id="stop">Stop</button>
+		</div>
 
 		<script>
-			let conn = new WebSocket('ws://' + window.location.host + '/ws')
-			let pc = new RTCPeerConnection()
+let conn = new WebSocket('ws://' + window.location.host + '/ws');
+let pc = new RTCPeerConnection({sdpSemantics: "unified-plan"});
+let cameraTrack = null;
+let localVideo = document.getElementById("localVideo");
+let remoteVideo = document.getElementById("remoteVideo");
 
-			pc.ontrack = function (event) {
-			  if (event.track.kind === 'audio') {
-				return
-			  }
+document.getElementById("start").addEventListener("click", function() {
+    if (cameraTrack === null)
+        startCamera();
+});
 
-			  var el = document.getElementById('video')
-			  el.srcObject = event.streams[0]
-			  el.autoplay = true
-			  el.controls = true
-			}
+document.getElementById("stop").addEventListener("click", function() {
+    if (cameraTrack !== null)
+        stopCamera();
+});
 
-			conn.onopen = () => {
-				console.log('Connection open')
-			}
-			conn.onclose = evt => {
-				console.log('Connection closed')
-			}
-			conn.onmessage = evt => {
-				let msg = JSON.parse(evt.data)
-				if (!msg) {
-					return console.log('failed to parse msg')
-				}
+function startCamera() {
+    navigator.mediaDevices.getUserMedia({video: true, audio: false}).then(function(stream) {
+        let videoTracks = stream.getVideoTracks();
+        if (videoTracks.length !== 1) {
+            console.log("Cannot acquire webcam video track.");
+            return;
+        }
 
-				switch (msg.event) {
-				case 'offer':
-					offer = JSON.parse(msg.data)
-					if (!offer) {
-						return console.log('failed to parse answer')
-					}
-					pc.setRemoteDescription(offer)
+        localVideo.srcObject = stream;
+        cameraTrack = videoTracks[0];
+        pc.addTrack(videoTracks[0]);
 
-					pc.createAnswer().then(answer => {
-						pc.setLocalDescription(answer)
-						conn.send(JSON.stringify({event: 'answer', data: JSON.stringify(answer)}))
-					})
-				}
-			}
-			window.conn = conn
+        console.log("Camera started.");
+    }).catch(function(exception) {
+        console.log(exception);
+    });
+}
+
+function stopCamera() {
+    if (cameraTrack === null)
+        return;
+
+    let senders = pc.getSenders();
+    for (let i = 0; i < senders.length; ++i) {
+        if (senders[i].track === cameraTrack) {
+            pc.removeTrack(senders[i]);
+            cameraTrack = null;
+            localVideo.srcObject = null;
+            remoteVideo.srcObject = null;
+            console.log("Camera stopped.");
+            return;
+        }
+    }
+
+    console.log("Cannot find sender for track", cameraTrack);
+}
+
+pc.onnegotiationneeded = function () {
+    pc.createOffer().then(function(offer) {
+        return pc.setLocalDescription(offer);
+    }).then(function(success) {
+        if (success !== false) {
+            console.log("Signal offer to server", pc.localDescription);
+            conn.send(JSON.stringify({event: 'offer', data: JSON.stringify(pc.localDescription)}));
+        }
+    }).catch(function(exception) {
+        console.log(exception);
+    });
+}
+
+pc.ontrack = function (event) {
+    if (event.track.kind === 'audio')
+        return;
+
+    console.log("New remote video track.");
+    remoteVideo.srcObject = event.streams[0];
+}
+
+conn.onopen = () => {
+    console.log('Connection open');
+}
+conn.onclose = evt => {
+    console.log('Connection closed');
+}
+conn.onmessage = evt => {
+    let msg = JSON.parse(evt.data);
+    if (!msg) {
+        return console.log("failed to parse msg");
+    }
+
+    switch (msg.event) {
+        case "answer":
+            console.log("Answer received.");
+            let answer = JSON.parse(msg.data);
+            if (!answer) {
+                console.log("failed to parse answer");
+                return;
+            }
+            pc.setRemoteDescription(answer).catch(function (exception) {
+                console.log(exception);
+            });
+            break;
+
+        default:
+            console.log("unhandled websocket event", msg.event);
+    }
+}
+window.conn = conn
 		</script>
 	</body>
 </html>
@@ -78,8 +175,8 @@ var (
 	}
 
 	peerConnectionConfig = webrtc.Configuration{}
-
-	videoTrack = &webrtc.TrackLocalStaticSample{}
+	peerConnection *webrtc.PeerConnection
+	//videoTrack = &webrtc.TrackLocalStaticSample{}
 )
 
 type websocketMessage struct {
@@ -88,40 +185,7 @@ type websocketMessage struct {
 }
 
 func main() {
-	var err error
-	videoTrack, err = webrtc.NewTrackLocalStaticSample(webrtc.RTPCodecCapability{MimeType: webrtc.MimeTypeVP8}, "video", "video")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	go func() {
-		file, ivfErr := os.Open("output.ivf")
-		if ivfErr != nil {
-			panic(ivfErr)
-		}
-
-		ivf, header, ivfErr := ivfreader.NewWith(file)
-		if ivfErr != nil {
-			panic(ivfErr)
-		}
-
-		ticker := time.NewTicker(time.Millisecond * time.Duration((float32(header.TimebaseNumerator)/float32(header.TimebaseDenominator))*1000))
-		for ; true; <-ticker.C {
-			frame, _, ivfErr := ivf.ParseNextFrame()
-			if ivfErr == io.EOF {
-				fmt.Printf("All video frames parsed and sent")
-				os.Exit(0)
-			}
-
-			if ivfErr != nil {
-				panic(ivfErr)
-			}
-
-			if ivfErr = videoTrack.WriteSample(media.Sample{Data: frame, Duration: time.Second}); ivfErr != nil {
-				panic(ivfErr)
-			}
-		}
-	}()
+	go setupPeerConnection()
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -133,7 +197,31 @@ func main() {
 }
 
 func sendOffer(pc *webrtc.PeerConnection, ws *websocket.Conn) error {
-	answer, err := pc.CreateOffer(nil)
+	offer, err := pc.CreateOffer(nil)
+	if err != nil {
+		return err
+	}
+
+	gatherComplete := webrtc.GatheringCompletePromise(pc)
+	if setErr := pc.SetLocalDescription(offer); setErr != nil {
+		return setErr
+	}
+	<-gatherComplete
+
+	offerString, err := json.Marshal(pc.LocalDescription())
+	if err != nil {
+		return err
+	}
+
+	log.Printf("Offer sent to browser.");
+	return ws.WriteJSON(&websocketMessage{
+		Event: "offer",
+		Data:  string(offerString),
+	})
+}
+
+func sendAnswer(pc *webrtc.PeerConnection, ws *websocket.Conn) error {
+	answer, err := pc.CreateAnswer(nil)
 	if err != nil {
 		return err
 	}
@@ -149,21 +237,39 @@ func sendOffer(pc *webrtc.PeerConnection, ws *websocket.Conn) error {
 		return err
 	}
 
+	log.Printf("Answer sent to browser.");
 	return ws.WriteJSON(&websocketMessage{
-		Event: "offer",
+		Event: "answer",
 		Data:  string(answerString),
 	})
 }
 
-func handleWebsocketMessage(pc *webrtc.PeerConnection, message *websocketMessage) error {
-	if message.Event == "answer" {
-		offer := webrtc.SessionDescription{}
-		if err := json.Unmarshal([]byte(message.Data), &offer); err != nil {
+func handleWebsocketMessage(pc *webrtc.PeerConnection, message *websocketMessage, ws *websocket.Conn) error {
+	if message.Event == "answer" || message.Event == "offer" {
+		log.Printf("Received %v\n", message.Event)
+
+		sdp := webrtc.SessionDescription{}
+		if err := json.Unmarshal([]byte(message.Data), &sdp); err != nil {
 			return err
 		}
 
-		return pc.SetRemoteDescription(offer)
+		if err := pc.SetRemoteDescription(sdp); err != nil {
+			return err
+		}
+
+		if message.Event == "answer" {
+			if err := sendOffer(pc, ws); err != nil {
+				return err
+			}
+		} else {
+			if err := sendAnswer(pc, ws); err != nil {
+				return err
+			}
+		}
+	} else {
+		log.Println("Unexpected websocket message.")
 	}
+
 	return nil
 }
 
@@ -176,30 +282,6 @@ func serveWs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	peerConnection, err := webrtc.NewPeerConnection(peerConnectionConfig)
-	if err != nil {
-		log.Print(err)
-		return
-	}
-
-	defer func() {
-		if closeErr := peerConnection.Close(); closeErr != nil {
-			log.Println(closeErr)
-		}
-	}()
-
-	if _, err = peerConnection.CreateDataChannel("HelloWorld", nil); err != nil {
-		log.Println(err)
-		return
-	}
-
-	if err = sendOffer(peerConnection, ws); err != nil {
-		log.Println(err)
-		return
-	}
-
-	go trackAddRemoveLoop(peerConnection, ws)
-
 	message := &websocketMessage{}
 	for {
 		_, msg, err := ws.ReadMessage()
@@ -210,34 +292,99 @@ func serveWs(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		if err := handleWebsocketMessage(peerConnection, message); err != nil {
+		if err := handleWebsocketMessage(peerConnection, message, ws); err != nil {
 			log.Print(err)
 		}
 	}
 }
 
-func trackAddRemoveLoop(peerConnection *webrtc.PeerConnection, ws *websocket.Conn) {
-	var (
-		currentRTPSender *webrtc.RTPSender
-		err              error
-	)
+func setupPeerConnection() {
+	var err error
 
-	ticker := time.NewTicker(time.Second * 5)
-	for range ticker.C {
-		fmt.Printf("removing track: %v\n", currentRTPSender == nil)
-		if currentRTPSender == nil {
-			if currentRTPSender, err = peerConnection.AddTrack(videoTrack); err != nil {
-				panic(err)
-			}
-		} else {
-			if err = peerConnection.RemoveTrack(currentRTPSender); err != nil {
-				panic(err)
-			}
-			currentRTPSender = nil
-		}
-
-		if err = sendOffer(peerConnection, ws); err != nil {
-			panic(err)
-		}
+	// Create a new RTCPeerConnection
+	peerConnection, err = webrtc.NewPeerConnection(peerConnectionConfig)
+	if err != nil {
+		panic(err)
 	}
+	defer func() {
+		if cErr := peerConnection.Close(); cErr != nil {
+			fmt.Printf("cannot close peerConnection: %v\n", cErr)
+		}
+	}()
+
+	// Create Track that we send video back to browser on
+	outputTrack, err := webrtc.NewTrackLocalStaticRTP(webrtc.RTPCodecCapability{MimeType: webrtc.MimeTypeVP8}, "video", "pion")
+	if err != nil {
+		panic(err)
+	}
+
+	// Add this newly created track to the PeerConnection
+	rtpSender, err := peerConnection.AddTrack(outputTrack)
+	if err != nil {
+		panic(err)
+	}
+
+	// Read incoming RTCP packets
+	// Before these packets are returned they are processed by interceptors. For things
+	// like NACK this needs to be called.
+	go func() {
+		rtcpBuf := make([]byte, 1500)
+		for {
+			if _, _, rtcpErr := rtpSender.Read(rtcpBuf); rtcpErr != nil {
+				return
+			}
+		}
+	}()
+
+	// Set a handler for when a new remote track starts, this handler copies inbound RTP packets,
+	// replaces the SSRC and sends them back
+	peerConnection.OnTrack(func(track *webrtc.TrackRemote, receiver *webrtc.RTPReceiver) {
+		// Send a PLI on an interval so that the publisher is pushing a keyframe every rtcpPLIInterval
+		// This is a temporary fix until we implement incoming RTCP events, then we would push a PLI only when a viewer requests it
+		go func() {
+			ticker := time.NewTicker(time.Second * 3)
+			for range ticker.C {
+				errSend := peerConnection.WriteRTCP([]rtcp.Packet{&rtcp.PictureLossIndication{MediaSSRC: uint32(track.SSRC())}})
+				if errSend != nil {
+					fmt.Println(errSend)
+				}
+			}
+		}()
+
+		fmt.Printf("Track %s has started, of type %d: %s \n", track.ID(), track.PayloadType(), track.Codec().MimeType)
+		for {
+			// Read RTP packets being sent to Pion
+			rtp, _, readErr := track.ReadRTP()
+
+			if readErr == io.EOF {
+				fmt.Printf("Track %s ended.", track.ID())
+				break
+			}
+
+			if readErr != nil {
+				panic(readErr)
+			}
+
+			if writeErr := outputTrack.WriteRTP(rtp); writeErr != nil {
+				panic(writeErr)
+			}
+		}
+	})
+
+	// Set the handler for Peer connection state
+	// This will notify you when the peer has connected/disconnected
+	peerConnection.OnConnectionStateChange(func(s webrtc.PeerConnectionState) {
+		fmt.Printf("Peer Connection State has changed: %s\n", s.String())
+
+		if s == webrtc.PeerConnectionStateFailed {
+			// Wait until PeerConnection has had no network activity for 30 seconds or another failure. It may be reconnected using an ICE Restart.
+			// Use webrtc.PeerConnectionStateDisconnected if you are interested in detecting faster timeout.
+			// Note that the PeerConnection may come back from PeerConnectionStateDisconnected.
+			fmt.Println("Peer Connection has gone to failed exiting")
+			os.Exit(0)
+		}
+	})
+
+	// Block forever
+	select {}
 }


### PR DESCRIPTION
Updated to use the webcam stream and start negotiation from browser instead of Pion.

The track sent by the browser does a loopback (inside Pion) and is replayed side-by-side with the local webcam stream following the steps in https://github.com/pion/webrtc/issues/1843#issuecomment-907664211

---

As indicated in https://github.com/pion/webrtc/issues/1843 the first time the start button is pressed, the track in return is correctly displayed in the video on the right. Subsequent times, the data arrives at the browser (inspecting via chrome: // webrtc-internals), but the video remains black.